### PR TITLE
Adding apt-get clean to the cleanup service

### DIFF
--- a/cleanup/apt-cleanup.service
+++ b/cleanup/apt-cleanup.service
@@ -12,7 +12,3 @@ ExecStart=/bin/bash -c "apt-get purge -y $(dpkg --list | egrep 'linux-(image|ima
 
 # Purge removed packages
 ExecStart=/bin/bash -c "apt-get autoremove -y; apt-get purge -y $(dpkg --list | grep '^rc' | awk '{print $2}') | tr '[:space:]' ' '"
-
-# Clears out the local repository of retrieved package files. It removes everything but the lock
-# file from /var/cache/apt/archives/ and /var/cache/apt/archives/partial/. (man apt-get)
-ExecStart=/bin/bash -c "apt-get clean -y"

--- a/cleanup/apt-cleanup.service
+++ b/cleanup/apt-cleanup.service
@@ -12,3 +12,7 @@ ExecStart=/bin/bash -c "apt-get purge -y $(dpkg --list | egrep 'linux-(image|ima
 
 # Purge removed packages
 ExecStart=/bin/bash -c "apt-get autoremove -y; apt-get purge -y $(dpkg --list | grep '^rc' | awk '{print $2}') | tr '[:space:]' ' '"
+
+# Clears out the local repository of retrieved package files. It removes everything but the lock
+# file from /var/cache/apt/archives/ and /var/cache/apt/archives/partial/. (man apt-get)
+ExecStart=/bin/bash -c "apt-get clean -y"

--- a/cleanup/init.sls
+++ b/cleanup/init.sls
@@ -28,3 +28,9 @@ apt-cleanup.timer:
     - name: systemctl daemon-reload
     - onchanges:
       - file: /etc/systemd/system/apt-cleanup.service
+
+apt_clean_packages:
+  file.managed:
+    - name: /etc/apt/apt.conf.d/30clean-packages
+    - contents: |
+        APT::Keep-Downloaded-Packages "false";

--- a/cleanup/init.sls
+++ b/cleanup/init.sls
@@ -31,6 +31,6 @@ apt-cleanup.timer:
 
 apt_clean_packages:
   file.managed:
-    - name: /etc/apt/apt.conf.d/30clean-packages
+    - name: /etc/apt/apt.conf.d/30remove-downloaded-packages
     - contents: |
         APT::Keep-Downloaded-Packages "false";

--- a/cleanup/now.sls
+++ b/cleanup/now.sls
@@ -26,3 +26,9 @@ apt_purge_packages:
           awk '{print $2}' | \
           tr '[:space:]' ' ' \
         )
+
+apt_clean_packages:
+  cmd.run:
+    - env:
+      - DEBIAN_FRONTEND: noninteractive
+    - name: apt-get clean -y


### PR DESCRIPTION
By default apt-get keeps installed package files in the local cache under /var/cache/apt. This can take up a lot of disk space over time.

The following line can be used to change this behavior:
APT::Keep-Downloaded-Packages "false";

Note: The apt command is different in that it deletes the package files after installation.

https://salsa.debian.org/apt-team/apt/blob/1.8.2/debian/NEWS#L109